### PR TITLE
Fix Pilot Tag Handling

### DIFF
--- a/Docs/Models/TaskforceObject_pilot_config.md
+++ b/Docs/Models/TaskforceObject_pilot_config.md
@@ -3,7 +3,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **image** | **String** | The image tag to use (e.g., &#39;v#.#.#&#39; or &#39;latest&#39;). This is useful for repeatability. | [default to null] |
+| **tag** | **String** | The image tag to use (e.g., &#39;#.#.#&#39;, &#39;latest&#39;, or a test branch tag). This is useful for repeatability. | [default to null] |
 | **environment** | [**Map**](TaskforceObject_pilot_config_environment_value.md) | Environment variables and their corresponding values. | [default to null] |
 | **input\_files** | **Set** | Paths to files to make available to the task container. These files must already be accessible on the AP. | [default to null] |
 

--- a/Docs/Models/pilot_config.md
+++ b/Docs/Models/pilot_config.md
@@ -3,7 +3,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **image** | **String** | The image tag to use (e.g., &#39;v#.#.#&#39; or &#39;latest&#39;). This is useful for repeatability. | [default to null] |
+| **tag** | **String** | The image tag to use (e.g., &#39;#.#.#&#39;, &#39;latest&#39;, or a test branch tag). This is useful for repeatability. | [default to null] |
 | **environment** | [**Map**](pilot_config_environment_value.md) | Environment variables and their corresponding values. | [default to null] |
 | **input\_files** | **Set** | Paths to files to make available to the task container. These files must already be accessible on the AP. | [default to null] |
 

--- a/examples/request_workflow.py
+++ b/examples/request_workflow.py
@@ -128,7 +128,7 @@ async def request_workflow(
                         "pilot_config": {
                             "environment": {},
                             "input_files": [],
-                            "image": pilot_cvmfs_image_tag,
+                            "tag": pilot_cvmfs_image_tag,
                         }
                     }
                     if pilot_cvmfs_image_tag

--- a/tests/integration/ewms_actions.py
+++ b/tests/integration/ewms_actions.py
@@ -106,7 +106,7 @@ async def user_requests_new_workflow(
     assert all(tf["n_workers"] == n_workers for tf in workflow_resp["taskforces"])
     for tf in workflow_resp["taskforces"]:
         expected = {
-            "image": os.environ["TEST_PILOT_IMAGE_LATEST_TAG"],
+            "tag": os.environ["TEST_PILOT_IMAGE_LATEST_TAG"],
             "environment": {
                 **environment,
                 "EWMS_PILOT_TASK_IMAGE": task_image,

--- a/tests/integration/test_mqs_scheduling.py
+++ b/tests/integration/test_mqs_scheduling.py
@@ -64,7 +64,7 @@ def _make_test_taskforce(task_directive: dict, location: str, i: int) -> dict:
         "schedd": f"schedd-{location}",
         "n_workers": 100,
         "pilot_config": {
-            "image": "v1.2.3",
+            "tag": "v1.2.3",
             "environment": {
                 "EWMS_PILOT_TASK_IMAGE": task_directive["task_image"],
                 "EWMS_PILOT_TASK_ARGS": task_directive["task_args"],

--- a/tests/integration/test_mqs_scheduling.py
+++ b/tests/integration/test_mqs_scheduling.py
@@ -64,7 +64,7 @@ def _make_test_taskforce(task_directive: dict, location: str, i: int) -> dict:
         "schedd": f"schedd-{location}",
         "n_workers": 100,
         "pilot_config": {
-            "tag": "v1.2.3",
+            "tag": "1.2.3",
             "environment": {
                 "EWMS_PILOT_TASK_IMAGE": task_directive["task_image"],
                 "EWMS_PILOT_TASK_ARGS": task_directive["task_args"],

--- a/wms/config.py
+++ b/wms/config.py
@@ -131,8 +131,8 @@ GH_API_PILOT_RELEASES_URL = (  # can't end in '/'
 
 
 @cachetools.func.ttl_cache(ttl=1 * 60)
-def get_pilot_image(tag: str) -> str:
-    """Get the uri to the pilot image."""
+def get_pilot_tag(tag: str) -> str:
+    """Get/validate the tag of the pilot image."""
     if tag == "latest":  # convert to immutable version tag
         url = urljoin(GH_API_PILOT_RELEASES_URL + "/", "latest")
         LOGGER.info(f"Retrieving pilot image info from {url} ...")

--- a/wms/rest_handlers/utils.py
+++ b/wms/rest_handlers/utils.py
@@ -1,4 +1,5 @@
 """Utils for REST routes."""
+
 import json
 import logging
 
@@ -33,7 +34,7 @@ def add_values_to_pilot_config(task_input: dict) -> dict:
 
     # attach defaults
     return {
-        "image": config.get_pilot_image(pilot_config.get("image", "latest")),
+        "tag": config.get_pilot_tag(pilot_config.get("tag", "latest")),
         "environment": pilot_config["environment"],
         "input_files": pilot_config.get("input_files", []),
     }

--- a/wms/schema/db/Taskforce.json
+++ b/wms/schema/db/Taskforce.json
@@ -41,10 +41,10 @@
             "type": "object",
             "description": "Configuration settings for the EWMS pilot.",
             "properties": {
-                "image": {
+                "tag": {
                     "type": "string",
-                    "description": "The image tag to use (e.g., 'v#.#.#' or 'latest'). This is useful for repeatability.",
-                    "pattern": "^(v[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})|(latest)$"
+                    "description": "The image tag to use (e.g., '#.#.#', 'latest', or a test branch tag). This is useful for repeatability.",
+                    "pattern": "^[a-z0-9._-]{1,128}$"
                 },
                 "environment": {
                     "type": "object",

--- a/wms/schema/db/Taskforce.json
+++ b/wms/schema/db/Taskforce.json
@@ -43,8 +43,8 @@
             "properties": {
                 "tag": {
                     "type": "string",
-                    "description": "The image tag to use (e.g., 'v#.#.#', 'latest', or a feature branch tag). This field is useful for repeatability.",
-                    "pattern": "^((v[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})|(latest)|((?!^[0-9.]+$)[a-z0-9._-]{1,128}))$"
+                    "description": "The image tag to use (e.g., '#.#.#', 'latest', or a feature branch tag). Note: tags like # or #.# are disallowed since these are mutable. This field is useful for repeatability.",
+                    "pattern": "^([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})|(latest)|((?!^[0-9.]+$)[a-z0-9._-]{1,128})$"
                 },
                 "environment": {
                     "type": "object",

--- a/wms/schema/db/Taskforce.json
+++ b/wms/schema/db/Taskforce.json
@@ -43,8 +43,8 @@
             "properties": {
                 "tag": {
                     "type": "string",
-                    "description": "The image tag to use (e.g., '#.#.#', 'latest', or a test branch tag). This is useful for repeatability.",
-                    "pattern": "^[a-z0-9._-]{1,128}$"
+                    "description": "The image tag to use (e.g., 'v#.#.#', 'latest', or a feature branch tag). This field is useful for repeatability.",
+                    "pattern": "^((v[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})|(latest)|((?!^[0-9.]+$)[a-z0-9._-]{1,128}))$"
                 },
                 "environment": {
                     "type": "object",

--- a/wms/schema/db/Taskforce.json
+++ b/wms/schema/db/Taskforce.json
@@ -80,7 +80,7 @@
             },
             "additionalProperties": false,
             "required": [
-                "image",
+                "tag",
                 "environment",
                 "input_files"
             ]

--- a/wms/schema/rest/openapi_compiled.json
+++ b/wms/schema/rest/openapi_compiled.json
@@ -182,10 +182,10 @@
                         "type": "object",
                         "description": "Configuration settings for the EWMS pilot.",
                         "properties": {
-                            "image": {
+                            "tag": {
                                 "type": "string",
-                                "description": "The image tag to use (e.g., 'v#.#.#' or 'latest'). This is useful for repeatability.",
-                                "pattern": "^(v[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})|(latest)$"
+                                "description": "The image tag to use (e.g., '#.#.#', 'latest', or a test branch tag). This is useful for repeatability.",
+                                "pattern": "^[a-z0-9._-]{1,128}$"
                             },
                             "environment": {
                                 "type": "object",
@@ -221,7 +221,7 @@
                         },
                         "additionalProperties": false,
                         "required": [
-                            "image",
+                            "tag",
                             "environment",
                             "input_files"
                         ]


### PR DESCRIPTION
The sub-field is now called `tag` (previously `image`) since it is a _tag_. Also, allow feature branch tags.