### PR TITLE
Add condor_requirements to get example working

### DIFF
--- a/examples/request_workflow.py
+++ b/examples/request_workflow.py
@@ -115,6 +115,7 @@ async def request_workflow(
                 "task_args": "cp {{INFILE}} {{OUTFILE}}",
                 "n_workers": n_workers,
                 "worker_config": {
+                    "condor_requirements": "",
                     "do_transfer_worker_stdouterr": True,
                     "max_worker_runtime": 60 * 10,
                     "n_cores": 1,


### PR DESCRIPTION
To get examples/request_workflow.py to work, I needed to add an empty condor_requirements field. Outside of this PR, I also had to:

- pip install oms-mqclient and pika
- Patch the headers in https://github.com/Observation-Management-Service/MQClient/blob/master/mqclient/broker_client_interface.py#L111 due to a serialization error
